### PR TITLE
Send events to react context when state for region determined

### DIFF
--- a/android/src/main/java/com/mackentoch/beaconsandroid/BeaconsAndroidModule.java
+++ b/android/src/main/java/com/mackentoch/beaconsandroid/BeaconsAndroidModule.java
@@ -224,17 +224,24 @@ public class BeaconsAndroidModule extends ReactContextBaseJavaModule implements 
     private MonitorNotifier mMonitorNotifier = new MonitorNotifier() {
         @Override
         public void didEnterRegion(Region region) {
+            Log.d(LOG_TAG, "didEnterRegion");
             sendEvent(mReactContext, "regionDidEnter", createMonitoringResponse(region));
         }
 
         @Override
         public void didExitRegion(Region region) {
+            Log.d(LOG_TAG, "didExitRegion!");
             sendEvent(mReactContext, "regionDidExit", createMonitoringResponse(region));
         }
 
         @Override
         public void didDetermineStateForRegion(int i, Region region) {
-
+            Log.d(LOG_TAG, "didDetermineStateForRegion with " + i);
+            if (i == MonitorNotifier.INSIDE) {
+                sendEvent(mReactContext, "regionInside", createMonitoringResponse(region));
+            } else if ( i == MonitorNotifier.OUTSIDE) {
+                sendEvent(mReactContext, "regionOutside", createMonitoringResponse(region));
+            }
         }
     };
 


### PR DESCRIPTION
Emit event via bridge to React context on didDetermineStateForRegion so apps can perform actions if mobile device is already inside the region or already outside the region
