### PR TITLE
updated altbeacons lib to 2.12+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,5 +29,5 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.facebook.react:react-native:0.12.+'
-    compile 'org.altbeacon:android-beacon-library:2.9.2'
+    compile 'org.altbeacon:android-beacon-library:2.12+'
 }


### PR DESCRIPTION
Updated altbeacons lib to 2.12+ 
http://www.davidgyoungtech.com/2017/08/07/beacon-detection-with-android-8